### PR TITLE
Adjust cs story path, add intent, test stories, qol action change

### DIFF
--- a/rasa/actions/actions.py
+++ b/rasa/actions/actions.py
@@ -65,23 +65,26 @@ class ActionRequestTopics(Action):
         # requested_topic = None
         # if topic in self.data:
             
-        requested_topic = topics.find_one({"lower_topic": topic.lower()})
-            #https://stackoverflow.com/questions/6266555/querying-mongodb-via-pymongo-in-case-insensitive-efficiently
-
-        if not requested_topic:
-            if not topic:
-                dispatcher.utter_message(text="I'm not well-trained on that topic...")
-            else:
-                str = ""
-                str += topic.lower()
-                dispatcher.utter_message(text=("I'm not well-trained on " + str))
+        if topic is None:
+            dispatcher.utter_message(text="Sorry, I don't quite understand your question... Try rephrasing.")
         else:
-            dispatcher.utter_message(text=("Here is what I know about " + topic.lower() + ": " + requested_topic["description"]))
-            dispatcher.utter_message(text=("What would you like to know about this topic?"), buttons=[
-                {"payload": "/request_class_by_topic{\"topic\": \"" + topic.lower() + "\"}", "title": "Classes?"},
-                {"payload": "/request_job_by_topic{\"topic\": \"" + topic.lower() + "\"}", "title": "Careers?"},
-                ])
-                
+            requested_topic = topics.find_one({"lower_topic": topic.lower()})
+                #https://stackoverflow.com/questions/6266555/querying-mongodb-via-pymongo-in-case-insensitive-efficiently
+
+            if not requested_topic:
+                if not topic:
+                    dispatcher.utter_message(text="I'm not well-trained on that topic...")
+                else:
+                    str = ""
+                    str += topic.lower()
+                    dispatcher.utter_message(text=("I'm not well-trained on " + str))
+            else:
+                dispatcher.utter_message(text=("Here is what I know about " + topic.lower() + ": " + requested_topic["description"]))
+                dispatcher.utter_message(text=("What would you like to know about this topic?"), buttons=[
+                    {"payload": "/request_class_by_topic{\"topic\": \"" + topic.lower() + "\"}", "title": "Classes?"},
+                    {"payload": "/request_job_by_topic{\"topic\": \"" + topic.lower() + "\"}", "title": "Careers?"},
+                    ])
+                    
 
         return []
     

--- a/rasa/data/nlu.yml
+++ b/rasa/data/nlu.yml
@@ -375,6 +375,29 @@ nlu:
     - are there other jobs in computer science?
     - anything else comp sci majors can do?
 
+- intent: common_cstopics
+  examples: |
+    - What can I learn about in CS?
+    - What do I learn about in Computer Science?
+    - What will I learn about in cs?
+    - What do they teach you in CS?
+    - which topics do they teach in cs?
+    - What do they teach in CS?
+    - What is taught in cs?
+    - What are some topics involved in Computer science?
+    - What is studied in CS?
+    - What do CS majors learn?
+    - What do computer science majors learn about?
+    - What topics do computer science majors learn about?
+    - What do computer science majors learn?
+    - CS topics?
+    - Computer Science topics?
+    - Tell me about cs topics
+    - Tell me about topics in computer science
+    - which topics are taught in computer science
+    - which topics are covered in computer science?
+
+
 - intent: request_topics
   examples: |
     - Can you tell me about [Concurrency]{"entity": "topic"}

--- a/rasa/data/stories.yml
+++ b/rasa/data/stories.yml
@@ -196,20 +196,26 @@ stories:
   - intent: other_cscareers
   - action: utter_other_cscareers
 
-- story: action request topics path
+- story: cs topics 1
   steps:
+  - intent: common_cstopics
+  - action: utter_common_cstopics
   - intent: request_topics
   - action: action_request_topics
 
-- story: action request class by topic
+- story: cs topics to class
   steps:
+  - intent: common_cstopics
+  - action: utter_common_cstopics
   - intent: request_topics
   - action: action_request_topics
   - intent: request_class_by_topic
   - action: action_request_class_by_topic
 
-- story: action request job by topic
+- story: cs topics to job
   steps:
+  - intent: common_cstopics
+  - action: utter_common_cstopics
   - intent: request_topics
   - action: action_request_topics
   - intent: request_job_by_topic

--- a/rasa/domain.yml
+++ b/rasa/domain.yml
@@ -23,6 +23,7 @@ intents:
   - modern_computers
   - common_cscareers
   - other_cscareers
+  - common_cstopics
   - request_action_test
   - request_topics:
       use_entities: true
@@ -197,6 +198,15 @@ https://www.bls.gov/oes/current/oes_nat.htm"
   - text: "Computer Science degrees cover a variety of topics potentially preparing students to pursue careers in related fields such as Hardware Design, Data Science, Digital Media, or Business.
 
 Earing a college degree demonstrates your ability to achieve and learn, traits helpful in many positions. Your major is only one indicator of fit. Personal experience, interests, and skills are also important and it is not uncommon for graduates to work outside their fields of study."
+
+  utter_common_cstopics:
+  - text: "Computer Science covers a variety of diverse topics, many of which are taught at the University of Florida. 
+  
+  Some of these topics include: operating systems, computer graphics, parallel computing, artificial intelligence, networking, cryptography, etc.
+  
+  For a complete list of subfields and their topics, refer to this link: https://en.wikipedia.org/wiki/Outline_of_computer_science
+  
+  You can ask me about any of the topics listed under each subfield."
 
 actions:
   - action_hello_world

--- a/rasa/tests/test_stories.yml
+++ b/rasa/tests/test_stories.yml
@@ -490,12 +490,20 @@ stories:
 - story: request topic 1-1
   steps:
   - user: |
+      What can I learn about in CS?
+    intent: common_cstopics
+  - action: utter_common_cstopics
+  - user: |
       Can you tell me about [concurrency]{"entity": "topic"}
     intent: request_topics
   - action: action_request_topics
 
 - story: request topic 1-2
   steps:
+  - user: |
+      What do they teach you in CS?
+    intent: common_cstopics
+  - action: utter_common_cstopics
   - user: |
       Can you tell me about [artifical intelligence]{"entity": "topic"}
     intent: request_topics
@@ -504,12 +512,20 @@ stories:
 - story: request topic 1-3
   steps:
   - user: |
+      Which topics do they teach in CS?
+    intent: common_cstopics
+  - action: utter_common_cstopics
+  - user: |
       Can you tell me about [Natural language processing]{"entity": "topic"}
     intent: request_topics
   - action: action_request_topics
 
 - story: request topic 2-1
   steps:
+  - user: |
+      What are some topics involved in Computer science?
+    intent: common_cstopics
+  - action: utter_common_cstopics
   - user: |
       What is [networking]{"entity": "topic"}
     intent: request_topics
@@ -518,12 +534,20 @@ stories:
 - story: request topic 2-2
   steps:
   - user: |
+      What is studied in CS?
+    intent: common_cstopics
+  - action: utter_common_cstopics
+  - user: |
       What is [Soft computing]{"entity": "topic"}
     intent: request_topics
   - action: action_request_topics
 
 - story: request topic 2-3
   steps:
+  - user: |
+      CS topics?
+    intent: common_cstopics
+  - action: utter_common_cstopics
   - user: |
       What is [computational complexity theory]{"entity": "topic"}
     intent: request_topics
@@ -532,6 +556,10 @@ stories:
 - story: request topic 3-1
   steps:
   - user: |
+      Tell me about topics in computer science
+    intent: common_cstopics
+  - action: utter_common_cstopics
+  - user: |
       What are [algorithms]{"entity": "topic"}
     intent: request_topics
   - action: action_request_topics
@@ -539,12 +567,20 @@ stories:
 - story: request topic 3-2
   steps:
   - user: |
+      What do computer science majors learn?
+    intent: common_cstopics
+  - action: utter_common_cstopics
+  - user: |
       What are [Data Structures]{"entity": "topic"}
     intent: request_topics
   - action: action_request_topics
 
 - story: request topic 3-3
   steps:
+  - user: |
+      What will I learn about in computer science?
+    intent: common_cstopics
+  - action: utter_common_cstopics
   - user: |
       What are [programming language pragmatics]{"entity": "topic"}
     intent: request_topics


### PR DESCRIPTION
Added a common_cstopics intent to make it so searches for specific career information was done after initially asking about cs topics. The response for this intent lists a few CS topics and provides a link for additional cs topics that can be asked about. 
Adjusted test stories to account for this.
Made a quality of life change to the request topic action, there was an issue where pymongo would throw an error if the topic being searched is NoneType.