### PR TITLE
Fix whitespace issue with class-code lookup table

### DIFF
--- a/rasa/data/nlu.yml
+++ b/rasa/data/nlu.yml
@@ -678,7 +678,7 @@ nlu:
     - CAP 3020
     - CAP 3027
     - CAP 3032
-    - CAP 3034 
+    - CAP 3034
     - CAP 3220
     - CAP 4053
     - CAP 4112


### PR DESCRIPTION
Removed whitespace on class-code lookup table, gets rid of warnings when training the bot.