### PR TITLE
Fix an issue with shell scripts not working on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+#Make sure that our linux docker shell scripts don't get switched to windows style endings
+*.sh            text eol=lf


### PR DESCRIPTION
By default git on windows changes all line endings to window style, which then causes problems when our linux docker isntances try to run them. This is especially a problem for the mongo seed data scripts.

I think this config will prevent git from doing that.