### PR TITLE
Fix for unknown class lookup, example_topics.

### DIFF
--- a/rasa/actions/actions.py
+++ b/rasa/actions/actions.py
@@ -220,7 +220,7 @@ class ActionRequestClassByCode(Action):
         class_result = courses.find_one({"code": class_request})
 
         if not class_result:
-            random_classes = random.sample(courses.distinct("class_code"), 3)
+            random_classes = random.sample(courses.distinct("code"), 3)
             if not class_request:
                 dispatcher.utter_message(text=("Sorry, I don't quite understand your question... try rephrasing, or ask about one of these classes."), buttons=[
                     {"payload": "/request_class_by_code{\"class_code\": \"" + random_classes[0] + "\"}", "title": random_classes[0]},

--- a/rasa/data/nlu.yml
+++ b/rasa/data/nlu.yml
@@ -750,3 +750,13 @@ nlu:
     - how do chatbots work
     - How can I make a chatbot?
     - how could I make a chatbot
+
+- intent: example_topics
+  examples: |
+    - What are some examples of topics in Computer Science?
+    - give me some example topics
+    - What are some examples of topics?
+    - Give me some examples of topics in Computer Science.
+    - List topic examples in CS.
+    - tell me about cs topic examples
+    - what topic examples are there in CompSci

--- a/rasa/tests/test_stories.yml
+++ b/rasa/tests/test_stories.yml
@@ -493,8 +493,10 @@ stories:
       which topics do they teach in cs?
     intent: common_cstopics
   - action: utter_common_cstopics
-  - action: example_topics
-  - action: action_request_topics
+  - user: |
+      what are some examples of cs topics?
+    intent: example_topics
+  - action: action_example_topics
 
 - story: request topic 4-2
   steps:
@@ -502,7 +504,10 @@ stories:
       which topics do they teach in cs?
     intent: common_cstopics
   - action: utter_common_cstopics
-  - action: example_topics
+  - user: |
+      /example_topics
+    intent: example_topics
+  - action: action_example_topics
   - user: |
       Tell me about [computational physics]{"entity": "topic"}
     intent: request_topics


### PR DESCRIPTION
- added missing intent ```example_topics``` to training data and updated test stories
- Noticed course code lookup fails if course is not in database. random.sample() code was not querying database with correct field name.